### PR TITLE
Bug: patch handling fixes

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -4,6 +4,8 @@
 
 const PLATYPUS_PORT : &str = "8001";
 const PLATYPUS_WORKERS : u16 = 4;
+const DB_HOST : &str = "wss://platypus-06a3rhk0qlrtj092qq5dgtl91o.aws-use1.surreal.cloud";
+const DB_NS : &str = "tmf";
 
 
 #[derive(Clone, Debug, Default)]
@@ -23,6 +25,8 @@ impl Config {
         match item {
             "PLATYPUS_PORT" => Some(PLATYPUS_PORT.to_string()),
             "PLATYPUS_WORKERS" => Some(PLATYPUS_WORKERS.to_string()),
+            "DB_HOST" => Some(DB_HOST.to_string()),
+            "DB_NS" => Some(DB_NS.to_string()),
             _ => None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,13 @@ async fn main() -> std::io::Result<()> {
 
     info!("Starting {pkg} v{ver}");
 
+    let config = Config::new();
+
     // Data objects to be pass in
     info!("Connecting to SurrealDB...");
-    let persist = Persistence::new().await;
+    let persist = Persistence::new(&config).await;
     // let persis = Persistence::default();
-    let config = Config::new();
+    
     info!("Connected.");
 
     // Extract port crom config, default if not found

--- a/src/model/tmf/mod.rs
+++ b/src/model/tmf/mod.rs
@@ -73,6 +73,19 @@ pub fn render_post_output<T : Serialize + HasId>(output : Result<Vec<T>,Platypus
     }
 }
 
+pub fn render_patch_output<T : Serialize + HasId>(output : Result<Vec<T>,PlatypusError>) -> HttpResponse {
+    match output {
+        Ok(v) => {
+            let item = v.first().unwrap();
+            HttpResponse::Accepted()
+                .append_header(("Location",item.get_href()))
+                .append_header(("Content-Language",CONTENT_LANGUAGE))
+                .json(item)
+        },
+        Err(e) => HttpResponse::BadRequest().json(e),
+    }
+}
+
 pub fn render_delete_output(output : Result<bool,PlatypusError>) -> HttpResponse {
     match output {
         Ok(_b) => HttpResponse::NoContent().finish(),

--- a/src/model/tmf/tmf620/tmf620_catalog_management.rs
+++ b/src/model/tmf/tmf620/tmf620_catalog_management.rs
@@ -1,6 +1,6 @@
 //! TMF620 Catalog Management Module
 
-use tmflib::tmf620::category::{Category, CategoryRef};
+use tmflib::tmf620::category::Category;
 use tmflib::tmf620::catalog::Catalog;
 use tmflib::tmf620::product_offering::ProductOffering;
 use tmflib::tmf620::product_offering_price::ProductOfferingPrice;

--- a/src/model/tmf/tmf620/tmf620_catalog_management.rs
+++ b/src/model/tmf/tmf620/tmf620_catalog_management.rs
@@ -127,16 +127,24 @@ impl TMF620CatalogManagement
     pub async fn get_catalog(&self, id : String, query_opts : QueryOptions) -> Result<Vec<Catalog>,PlatypusError>  {
         self.persist.as_ref().unwrap().get_item(id,query_opts).await
     }
-    
-    pub async fn patch_specification(&self, id : String, patch : String) -> Result<Vec<ProductSpecification>,PlatypusError> {
+
+    pub async fn patch_category(&self, id : String, patch : Category) -> Result<Vec<Category>,PlatypusError> {
         self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
     }
 
-    pub async fn patch_offering(&self, id : String, patch : String) -> Result<Vec<ProductOffering>, PlatypusError> {
+    pub async fn patch_catalog(&self, id : String, patch : Catalog) -> Result<Vec<Catalog>,PlatypusError> {
         self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
     }
     
-    pub async fn patch_price(&self, id : String, patch : String) -> Result<Vec<ProductOfferingPrice>, PlatypusError> {
+    pub async fn patch_specification(&self, id : String, patch : ProductSpecification) -> Result<Vec<ProductSpecification>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+
+    pub async fn patch_offering(&self, id : String, patch : ProductOffering) -> Result<Vec<ProductOffering>, PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+    
+    pub async fn patch_price(&self, id : String, patch : ProductOfferingPrice) -> Result<Vec<ProductOfferingPrice>, PlatypusError> {
         self.persist.as_ref().unwrap().patch_tmf_item(id,patch).await
     }
 

--- a/src/model/tmf/tmf629/mod.rs
+++ b/src/model/tmf/tmf629/mod.rs
@@ -155,6 +155,7 @@ pub fn config_tmf629(cfg: &mut web::ServiceConfig) {
         .service(tmf629_list_handler)
         .service(tmf629_get_handler)
         .service(tmf629_create_handler)
+        .service(tmf629_patch_handler)
         .service(tmf629_delete_handler)
         .app_data(web::Data::new(Mutex::new(tmf629)));
 }

--- a/src/model/tmf/tmf629/tmf629_customer_management.rs
+++ b/src/model/tmf/tmf629/tmf629_customer_management.rs
@@ -32,6 +32,10 @@ impl TMF629CustomerManagement {
         self.persist.as_mut().unwrap().create_tmf_item(item).await
     }
 
+    pub async fn update_customer(&self, id: String, patch : Customer) -> Result<Vec<Customer>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+
     pub async fn delete_customer(&self, id : String) -> Result<bool, PlatypusError> {
         self.persist.as_ref().unwrap().delete_tmf_item::<Customer>(id).await
     }

--- a/src/model/tmf/tmf632/mod.rs
+++ b/src/model/tmf/tmf632/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Mutex;
 use tmf632_party_management::TMF632PartyManagement;
-use actix_web::{get,post,delete, web, HttpResponse, Responder};
+use actix_web::{get,post,patch, delete, web, HttpResponse, Responder};
 
 // TMFLIB
 #[cfg(all(feature = "tmf632",feature="v4"))]
@@ -23,6 +23,7 @@ use crate::model::tmf::{
     render_list_output,
     render_get_output,
     render_post_output,
+    render_patch_output,
     render_delete_output,
 };
 
@@ -110,6 +111,35 @@ pub async fn tmf632_post_handler_v4(
         }
     } 
 }
+
+/// Update an object
+#[patch("/tmf-api/partyManagement/v4/{object}/{id}")]
+pub async fn tmf632_patch_handler(
+    path : web::Path<(String,String)>,
+    tmf632: web::Data<Mutex<TMF632PartyManagement>>,
+    persist: web::Data<Mutex<Persistence>>,
+    raw: web::Bytes,
+) -> impl Responder {
+    let (object,id) = path.into_inner();
+    let json = String::from_utf8(raw.to_vec()).unwrap();
+    let mut tmf632 = tmf632.lock().unwrap();
+    let persist = persist.lock().unwrap();
+    tmf632.persist(persist.clone());
+    match object.as_str() {
+        "individual" => {
+            let individual : Individual = serde_json::from_str(json.as_str()).unwrap();
+            let result = tmf632.update_individual(id, individual).await;
+            render_patch_output(result)
+        },
+        "organization" => {
+            let organization : Organization = serde_json::from_str(json.as_str()).unwrap();
+            let result = tmf632.update_organization(id, organization).await;
+            render_patch_output(result)
+        },
+        _ => HttpResponse::BadRequest().json(PlatypusError::from("PATCH: Bad object: {object}"))
+    } 
+}
+
 
 /// Get a specific object
 #[delete("/tmf-api/partyManagement/v4/{object}/{id}")]

--- a/src/model/tmf/tmf632/mod.rs
+++ b/src/model/tmf/tmf632/mod.rs
@@ -175,6 +175,7 @@ pub fn config_tmf632(cfg: &mut web::ServiceConfig) {
         .service(tmf632_list_handler_v4)
         .service(tmf632_get_handler_v4)
         .service(tmf632_post_handler_v4)
+        .service(tmf632_patch_handler)
         .service(tmf632_delete_handler_v4)
         .app_data(web::Data::new(Mutex::new(tmf632.clone())));
 }

--- a/src/model/tmf/tmf632/tmf632_party_management.rs
+++ b/src/model/tmf/tmf632/tmf632_party_management.rs
@@ -36,6 +36,10 @@ impl TMF632PartyManagement {
         self.persist.as_mut().unwrap().get_item(id,query_opts).await
     }
 
+    pub async fn update_individual(&self, id : String, patch : Individual) -> Result<Vec<Individual>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+
     pub async fn delete_individual(&mut self, id : String) -> Result<bool,PlatypusError> {
         self.persist.as_mut().unwrap().delete_tmf_item::<Individual>(id).await
     }
@@ -50,6 +54,10 @@ impl TMF632PartyManagement {
 
     pub async fn get_organization(&mut self, id : String, query_opts : QueryOptions) -> Result<Vec<Organization>,PlatypusError> {
         self.persist.as_mut().unwrap().get_item(id,query_opts).await
+    }
+
+    pub async fn update_organization(&self, id : String, patch : Organization) -> Result<Vec<Organization>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
     }
 
     pub async fn delete_organization(&mut self, id : String) -> Result<bool,PlatypusError> {

--- a/src/model/tmf/tmf633/tmf633_service_catalog_management.rs
+++ b/src/model/tmf/tmf633/tmf633_service_catalog_management.rs
@@ -29,6 +29,10 @@ impl TMF633ServiceCatalogManagement {
         self.persist.as_ref().unwrap().get_items(query_opts).await
     }
 
+    pub async fn update_candidate(&self, id : String, patch : ServiceCandidate) -> Result<Vec<ServiceCandidate>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+
     // pub async fn get_catalogs(&self, query_opts : QueryOptions) -> Result<Vec<ServiceCatalog>,PlatypusError> {
     //     self.persist.as_ref().unwrap().get_items(query_opts).await
     // }
@@ -39,5 +43,9 @@ impl TMF633ServiceCatalogManagement {
 
     pub async fn get_specifications(&self, query_opts : QueryOptions) -> Result<Vec<ServiceSpecification>,PlatypusError> {
         self.persist.as_ref().unwrap().get_items(query_opts).await
+    }
+
+    pub async fn update_specification(&self, id : String, patch : ServiceSpecification) -> Result<Vec<ServiceSpecification>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
     }
 }

--- a/src/model/tmf/tmf648/mod.rs
+++ b/src/model/tmf/tmf648/mod.rs
@@ -110,5 +110,6 @@ pub fn config_tmf648(cfg: &mut web::ServiceConfig) {
     cfg
         .service(tmf648_list_handler)
         .service(tmf648_create_handler)
+        .service(tmf648_patch_handler)
         .app_data(web::Data::new(Mutex::new(tmf648)));
 }

--- a/src/model/tmf/tmf648/mod.rs
+++ b/src/model/tmf/tmf648/mod.rs
@@ -5,7 +5,7 @@
 use std::sync::Mutex;
 use actix_web::{
     get,
-    // patch,
+    patch,
     post,
     // delete,
     web, 
@@ -17,6 +17,7 @@ use crate::model::tmf::{
     // render_get_output,
     render_list_output,
     render_post_output,
+    render_patch_output,
 };
 
 // TMFLIB
@@ -54,6 +55,28 @@ pub async fn tmf648_create_handler(
             HttpResponse::BadRequest().json(PlatypusError::from("Invalid Object: {object}"))
         }
     }
+}
+
+#[patch("/tmf-api/quoteManagement/v4/{object}/{id}")]
+pub async fn tmf648_patch_handler(
+    path : web::Path<(String,String)>,
+    tmf648: web::Data<Mutex<TMF648QuoteManagement>>,
+    persist: web::Data<Mutex<Persistence>>,
+    raw: web::Bytes,
+) -> impl Responder {
+    let (object,id) = path.into_inner();
+    let json = String::from_utf8(raw.to_vec()).unwrap();
+    let mut tmf648 = tmf648.lock().unwrap();
+    let persist = persist.lock().unwrap();
+    tmf648.persist(persist.clone());
+    match object.as_str() {
+        "quote" => {
+            let quote : Quote = serde_json::from_str(json.as_str()).unwrap();
+            let result = tmf648.update_quote(id, quote).await;
+            render_patch_output(result)
+        },
+        _ => HttpResponse::BadRequest().json(PlatypusError::from("PATCH: Bad object: {object}"))
+    } 
 }
 
 #[get("/tmf-api/quoteManagement/v4/{object}")]

--- a/src/model/tmf/tmf648/tmf648_quote_management.rs
+++ b/src/model/tmf/tmf648/tmf648_quote_management.rs
@@ -28,4 +28,8 @@ impl TMF648QuoteManagement {
     pub async fn add_quote(&mut self, item : Quote) -> Result<Vec<Quote>,PlatypusError> {
         self.persist.as_mut().unwrap().create_tmf_item(item).await
     }
+
+    pub async fn update_quote(&self, id : String, patch : Quote) -> Result<Vec<Quote>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
 }

--- a/src/model/tmf/tmf674/mod.rs
+++ b/src/model/tmf/tmf674/mod.rs
@@ -153,6 +153,7 @@ pub fn config_tmf674(cfg: &mut web::ServiceConfig) {
         .service(tmf674_list_handler)
         .service(tmf674_get_handler)
         .service(tmf674_post_handler)
+        .service(tmf674_patch_handler)
         .service(tmf674_delete_handler)
         .app_data(web::Data::new(Mutex::new(tmf674.clone())));
 }

--- a/src/model/tmf/tmf674/mod.rs
+++ b/src/model/tmf/tmf674/mod.rs
@@ -8,7 +8,7 @@ use crate::common::error::PlatypusError;
 use crate::QueryOptions;
 use actix_web::{
     get,
-    // patch,
+    patch,
     post,
     delete,
     web, 
@@ -17,9 +17,10 @@ use actix_web::{
 };
 
 use crate::model::tmf::{
-    render_get_output,
+    // render_get_output,
     render_list_output,
     render_post_output,
+    render_patch_output,
     render_delete_output,
 };
 
@@ -97,6 +98,30 @@ pub async fn tmf674_post_handler(
         }
     }
 }
+
+/// Update an object
+#[patch("/tmf-api/geographicSiteManagement/v4/{object}/{id}")]
+pub async fn tmf674_patch_handler(
+    path : web::Path<(String,String)>,
+    tmf674: web::Data<Mutex<TMF674GeographicSiteManagement>>,
+    persist: web::Data<Mutex<Persistence>>,
+    raw: web::Bytes,
+) -> impl Responder {
+    let (object,id) = path.into_inner();
+    let json = String::from_utf8(raw.to_vec()).unwrap();
+    let mut tmf674 = tmf674.lock().unwrap();
+    let persist = persist.lock().unwrap();
+    tmf674.persist(persist.clone());
+    match object.as_str() {
+        "site" => {
+            let site : GeographicSite = serde_json::from_str(json.as_str()).unwrap();
+            let result = tmf674.update_site(id, site).await;
+            render_patch_output(result)
+        },
+        _ => HttpResponse::BadRequest().json(PlatypusError::from("PATCH: Bad object: {object}"))
+    } 
+}
+
 
 #[delete("/tmf-api/geographicSiteManagement/v4/{object}/{id}")]
 pub async fn tmf674_delete_handler(

--- a/src/model/tmf/tmf674/tmf674_geographic_site.rs
+++ b/src/model/tmf/tmf674/tmf674_geographic_site.rs
@@ -40,6 +40,10 @@ impl TMF674GeographicSiteManagement {
         self.persist.as_ref().unwrap().get_item(id,query_opts).await
     }
 
+    pub async fn update_site(&self, id : String, patch : GeographicSite) -> Result<Vec<GeographicSite>,PlatypusError> {
+        self.persist.as_ref().unwrap().patch_tmf_item(id, patch).await
+    }
+
     pub async fn delete_site(&mut self, id : String) -> Result<bool,PlatypusError> {
         self.persist.as_mut().unwrap().delete_tmf_item::<GeographicSite>(id).await
     }


### PR DESCRIPTION
Fixed Patch operation by:

- Fixed partial payload creation to match TMF object
- Set id on payload to avoid panic.
- Create renderer for patch output
- Simplify handling of patch for all objects.
- Pass config into DB